### PR TITLE
Fixed require of rmagick

### DIFF
--- a/lib/color_util.rb
+++ b/lib/color_util.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require 'rmagick'
 require "color_util/version"
 
 # -*- encoding : utf-8 -*-

--- a/lib/color_util/version.rb
+++ b/lib/color_util/version.rb
@@ -1,3 +1,3 @@
 class ColorUtil
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
This PR changes the require of rmagick so that we no longer receive the deprecation warning when the application loads. I also bumped the version number to 0.0.3.

Once merged, I understand we'll need to create a tag. Please let know if that's something I should do or if you'll take care of it.
